### PR TITLE
Add configurable database path and migration support

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "db_path": "website_verification.db"
+}


### PR DESCRIPTION
## Summary
- read database path from new `config.json`
- allow selecting database path in settings UI
- update configuration and optionally migrate data when saving settings
- use open dialog for selecting existing database file

## Testing
- `python -m py_compile mainV3.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a8ff076f88327afaba587bff70d0c