### PR TITLE
Display scan progress bar alongside control buttons

### DIFF
--- a/mainV3.py
+++ b/mainV3.py
@@ -347,7 +347,16 @@ class WebsiteVerificationTool:
         ttk.Button(bulk_frame, text="Scan All", command=self.scan_all_websites).pack(side=tk.LEFT, padx=5)
         ttk.Button(bulk_frame, text="Scan Selected", command=self.scan_selected).pack(side=tk.LEFT, padx=5)
         ttk.Button(bulk_frame, text="Delete Selected", command=self.delete_selected).pack(side=tk.LEFT, padx=5)
-        
+
+        # Progress bar, status label, and cancel button for scanning (hidden initially)
+        self.progress_frame = ttk.Frame(bulk_frame)
+        self.scan_progress = ttk.Progressbar(self.progress_frame, mode='determinate')
+        self.progress_bottom = ttk.Frame(self.progress_frame)
+        self.scan_status_label = ttk.Label(self.progress_bottom, text="")
+        self.cancel_scan_button = ttk.Button(
+            self.progress_bottom, text="Cancel", command=self.cancel_scan, state=tk.DISABLED
+        )
+
         # Websites list
         list_frame = ttk.LabelFrame(self.websites_frame, text="Monitored Websites", padding=10)
         list_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=(0, 10))
@@ -404,13 +413,6 @@ class WebsiteVerificationTool:
 
         # Bind double-click to view details
         self.websites_tree.bind('<Double-1>', self.view_website_details)
-
-        # Progress bar, status label, and cancel button for scanning (hidden initially)
-        self.progress_frame = ttk.Frame(self.websites_frame)
-        self.scan_progress = ttk.Progressbar(self.progress_frame, mode='determinate')
-        self.progress_bottom = ttk.Frame(self.progress_frame)
-        self.scan_status_label = ttk.Label(self.progress_bottom, text="")
-        self.cancel_scan_button = ttk.Button(self.progress_bottom, text="Cancel", command=self.cancel_scan, state=tk.DISABLED)
 
     def sort_websites_tree(self, column, reverse):
         """Sort the websites treeview by a given column."""
@@ -1801,13 +1803,12 @@ class WebsiteVerificationTool:
         self.scan_status_label.config(text=f"Scanning 0/{total}...")
         self.cancel_scan_button.config(state=tk.NORMAL)
 
-        if not self.scan_progress.winfo_manager():
-            self.scan_progress.pack(fill=tk.X, padx=10, pady=(5, 2))
-            self.progress_bottom.pack(fill=tk.X, padx=10)
+        if not self.progress_frame.winfo_manager():
+            self.progress_frame.pack(side=tk.LEFT, fill=tk.X, expand=True, padx=10)
+            self.scan_progress.pack(fill=tk.X, pady=(5, 2))
+            self.progress_bottom.pack(fill=tk.X)
             self.scan_status_label.pack(side=tk.LEFT)
             self.cancel_scan_button.pack(side=tk.RIGHT)
-
-        self.progress_frame.place(relx=0.5, rely=0.5, anchor='center')
 
     def update_scan_progress(self, current, total):
         """Update progress bar and status label"""
@@ -1819,7 +1820,7 @@ class WebsiteVerificationTool:
         self.scan_progress['value'] = 0
         self.scan_status_label.config(text="")
         self.cancel_scan_button.config(state=tk.DISABLED)
-        self.progress_frame.place_forget()
+        self.progress_frame.pack_forget()
 
     def cancel_scan(self):
         """Signal the active scan to cancel"""


### PR DESCRIPTION
## Summary
- Position scan progress bar and cancel button to the right of website control buttons for better use of space.
- Update progress bar show/hide logic to pack/unpack in the controls area.

## Testing
- `python -m py_compile mainV3.py`


------
https://chatgpt.com/codex/tasks/task_e_689a98cb7ef8832799a6e44a639f57e6