### PR TITLE
Enable sorting on Scan Results columns

### DIFF
--- a/mainV3.py
+++ b/mainV3.py
@@ -50,6 +50,10 @@ class WebsiteVerificationTool:
         self.last_sort_column = None
         self.last_sort_reverse = False
 
+        # Sorting state for scan results treeview
+        self.results_last_sort_column = None
+        self.results_last_sort_reverse = False
+
         # Scan state
         self.is_scanning = False
         self.scan_cancelled = False
@@ -420,16 +424,22 @@ class WebsiteVerificationTool:
 
         def sort_key(item):
             value = item[0]
+            if column in ("Last Checked", "Added", "Date"):
+                try:
+                    dt = datetime.fromisoformat(value)
+                except (ValueError, TypeError):
+                    dt = datetime.min
+                return (0, dt)
             try:
-                return float(value)
+                return (1, float(value))
             except (ValueError, TypeError):
                 match = re.search(r'-?\d+(?:\.\d+)?', str(value))
                 if match:
                     try:
-                        return float(match.group())
+                        return (1, float(match.group()))
                     except ValueError:
                         pass
-                return str(value).lower()
+                return (2, str(value).lower())
 
         data.sort(key=sort_key, reverse=reverse)
 
@@ -454,6 +464,53 @@ class WebsiteVerificationTool:
 
         self.last_sort_column = column
         self.last_sort_reverse = reverse
+
+    def sort_results_tree(self, column, reverse):
+        """Sort the scan results treeview by a given column."""
+        data = [(self.results_tree.set(k, column), k) for k in self.results_tree.get_children('')]
+
+        def sort_key(item):
+            value = item[0]
+            if column in ("Date", "Last Checked", "Added"):
+                try:
+                    dt = datetime.fromisoformat(value)
+                except (ValueError, TypeError):
+                    dt = datetime.min
+                return (0, dt)
+            try:
+                return (1, float(value))
+            except (ValueError, TypeError):
+                match = re.search(r'-?\d+(?:\.\d+)?', str(value))
+                if match:
+                    try:
+                        return (1, float(match.group()))
+                    except ValueError:
+                        pass
+                return (2, str(value).lower())
+
+        data.sort(key=sort_key, reverse=reverse)
+
+        for index, (_, k) in enumerate(data):
+            self.results_tree.move(k, '', index)
+
+        for col in self.results_tree["columns"]:
+            heading_text = col
+            if col == column:
+                heading_text += ' ▼' if reverse else ' ▲'
+                self.results_tree.heading(
+                    col,
+                    text=heading_text,
+                    command=lambda _col=col, _rev=not reverse: self.sort_results_tree(_col, _rev)
+                )
+            else:
+                self.results_tree.heading(
+                    col,
+                    text=heading_text,
+                    command=lambda _col=col: self.sort_results_tree(_col, False)
+                )
+
+        self.results_last_sort_column = column
+        self.results_last_sort_reverse = reverse
 
     def setup_results_tab(self):
         # Filter frame
@@ -480,7 +537,11 @@ class WebsiteVerificationTool:
         self.results_tree = ttk.Treeview(results_list_frame, columns=columns, show='headings')
         
         for col in columns:
-            self.results_tree.heading(col, text=col)
+            self.results_tree.heading(
+                col,
+                text=col,
+                command=lambda _col=col: self.sort_results_tree(_col, False)
+            )
             self.results_tree.column(col, width=120)
         
         # Scrollbar for results
@@ -2020,6 +2081,10 @@ class WebsiteVerificationTool:
                 result[7]  # Risk score
             )
             self.results_tree.insert('', tk.END, values=formatted_result)
+
+        # Reapply previous sorting if available
+        if self.results_last_sort_column:
+            self.sort_results_tree(self.results_last_sort_column, self.results_last_sort_reverse)
     
     def apply_results_filter(self):
         """Apply filters to scan results"""


### PR DESCRIPTION
## Summary
- make Scan Results table headers clickable to sort by column
- keep track of last sort column and direction across refreshes
- parse date values when sorting to avoid type errors on Last Checked columns

## Testing
- `python -m py_compile mainV3.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a9b46012c832784b922eb709666a2