### PR TITLE
Add scan comparison report and CSV export

### DIFF
--- a/mainV3.py
+++ b/mainV3.py
@@ -16,6 +16,7 @@ import os
 import json
 import shutil
 import re
+import csv
 from urllib.parse import urlparse
 import subprocess
 import sys
@@ -57,6 +58,9 @@ class WebsiteVerificationTool:
         # Scan state
         self.is_scanning = False
         self.scan_cancelled = False
+
+        # Storage for last comparison report
+        self.last_scan_diff_rows = []
 
         self.setup_ui()
         self.apply_theme(self.settings.get('theme', 'light'))
@@ -662,10 +666,12 @@ class WebsiteVerificationTool:
         # Report generation
         report_frame = ttk.LabelFrame(self.reports_frame, text="Generate Reports", padding=10)
         report_frame.pack(fill=tk.X, padx=10, pady=10)
-        
+
         ttk.Button(report_frame, text="Risk Assessment Report", command=self.generate_risk_report).pack(side=tk.LEFT, padx=5)
         ttk.Button(report_frame, text="Changes Report", command=self.generate_changes_report).pack(side=tk.LEFT, padx=5)
         ttk.Button(report_frame, text="Weekly Summary", command=self.generate_weekly_summary).pack(side=tk.LEFT, padx=5)
+        ttk.Button(report_frame, text="Scan Comparison", command=self.generate_scan_comparison_report).pack(side=tk.LEFT, padx=5)
+        ttk.Button(report_frame, text="Export CSV", command=self.export_scan_comparison_csv).pack(side=tk.LEFT, padx=5)
         
         # Report display
         self.report_text = scrolledtext.ScrolledText(self.reports_frame, height=30)
@@ -2458,6 +2464,166 @@ Additional Checks: {scan[15] if len(scan) > 15 else scan[12]}
         # Send email notification if enabled
         if self.settings.get('notification_emails'):
             self.send_notification_email("Weekly Website Security Summary", report)
+
+    def generate_scan_comparison_report(self):
+        """Compare most recent scans against previous ones"""
+        self.last_scan_diff_rows = []
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        cursor.execute("SELECT id, name, url FROM websites")
+        websites = cursor.fetchall()
+
+        sections = {
+            "MX Record Changes": [],
+            "Status Code Changes": [],
+            "SSL Changes": [],
+            "Registrar Changes": []
+        }
+        skipped = []
+
+        for site_id, name, url in websites:
+            cursor.execute(
+                """
+                SELECT scan_date, status_code, ssl_valid, ssl_issuer, ssl_expiry,
+                       mx_record_count, mx_records, registrar
+                FROM scan_results
+                WHERE website_id = ?
+                ORDER BY scan_date DESC
+                LIMIT 2
+                """,
+                (site_id,)
+            )
+            rows = cursor.fetchall()
+            if len(rows) < 2:
+                skipped.append(f"{name} ({url})")
+                continue
+
+            curr, prev = rows[0], rows[1]
+            curr_date, prev_date = curr[0], prev[0]
+
+            if curr[1] != prev[1]:
+                sections["Status Code Changes"].append(
+                    f"{name} ({url}): {prev[1]} -> {curr[1]}"
+                )
+                self.last_scan_diff_rows.append({
+                    "Category": "Status Code",
+                    "Website": name,
+                    "URL": url,
+                    "Previous": prev[1],
+                    "Current": curr[1],
+                    "Prev Scan": prev_date,
+                    "Current Scan": curr_date,
+                })
+
+            prev_ssl = f"valid={prev[2]} issuer={prev[3]} expiry={prev[4]}"
+            curr_ssl = f"valid={curr[2]} issuer={curr[3]} expiry={curr[4]}"
+            if prev_ssl != curr_ssl:
+                sections["SSL Changes"].append(
+                    f"{name} ({url}): {prev_ssl} -> {curr_ssl}"
+                )
+                self.last_scan_diff_rows.append({
+                    "Category": "SSL",
+                    "Website": name,
+                    "URL": url,
+                    "Previous": prev_ssl,
+                    "Current": curr_ssl,
+                    "Prev Scan": prev_date,
+                    "Current Scan": curr_date,
+                })
+
+            prev_mx = f"{prev[5]} records: {prev[6]}"
+            curr_mx = f"{curr[5]} records: {curr[6]}"
+            if prev_mx != curr_mx:
+                sections["MX Record Changes"].append(
+                    f"{name} ({url}): {prev_mx} -> {curr_mx}"
+                )
+                self.last_scan_diff_rows.append({
+                    "Category": "MX Records",
+                    "Website": name,
+                    "URL": url,
+                    "Previous": prev_mx,
+                    "Current": curr_mx,
+                    "Prev Scan": prev_date,
+                    "Current Scan": curr_date,
+                })
+
+            if curr[7] != prev[7]:
+                sections["Registrar Changes"].append(
+                    f"{name} ({url}): {prev[7]} -> {curr[7]}"
+                )
+                self.last_scan_diff_rows.append({
+                    "Category": "Registrar",
+                    "Website": name,
+                    "URL": url,
+                    "Previous": prev[7],
+                    "Current": curr[7],
+                    "Prev Scan": prev_date,
+                    "Current Scan": curr_date,
+                })
+
+        conn.close()
+
+        report = "SCAN COMPARISON REPORT\n"
+        report += f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        report += "="*60 + "\n\n"
+
+        order = [
+            ("MX Record Changes", "⚠️ MX RECORD CHANGES"),
+            ("Status Code Changes", "STATUS CODE CHANGES"),
+            ("SSL Changes", "SSL CHANGES"),
+            ("Registrar Changes", "REGISTRAR CHANGES"),
+        ]
+
+        for key, header in order:
+            lines = sections[key]
+            if lines:
+                report += header + "\n" + "-"*40 + "\n"
+                for line in lines:
+                    report += line + "\n"
+                report += "\n"
+
+        if skipped:
+            report += "SKIPPED (insufficient scans):\n" + "-"*40 + "\n"
+            for line in skipped:
+                report += f"{line}\n"
+
+        self.report_text.delete(1.0, tk.END)
+        self.report_text.insert(1.0, report)
+
+    def export_scan_comparison_csv(self):
+        """Export last scan comparison to CSV"""
+        if not self.last_scan_diff_rows:
+            messagebox.showwarning("No Data", "Generate a scan comparison report first.")
+            return
+
+        file_path = filedialog.asksaveasfilename(
+            defaultextension=".csv",
+            filetypes=[("CSV Files", "*.csv")],
+        )
+        if not file_path:
+            return
+
+        try:
+            with open(file_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(
+                    f,
+                    fieldnames=[
+                        "Category",
+                        "Website",
+                        "URL",
+                        "Previous",
+                        "Current",
+                        "Prev Scan",
+                        "Current Scan",
+                    ],
+                )
+                writer.writeheader()
+                for row in self.last_scan_diff_rows:
+                    writer.writerow(row)
+            messagebox.showinfo("Success", f"CSV exported to {file_path}")
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to export CSV: {e}")
 
 def install_requirements():
     """Install required packages"""


### PR DESCRIPTION
## Summary
- Add Scan Comparison and Export CSV buttons in reports tab
- Compare latest scan results to previous ones and group changes
- Allow exporting comparison data to CSV

## Testing
- `python -m py_compile mainV3.py`
- `python mainV3.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests python-whois dnspython` *(fails: Could not find a version that satisfies the requirement requests)*

------
https://chatgpt.com/codex/tasks/task_e_689b423141648327960d41bbb2f9d483