### PR TITLE
Handle whois module variations and fix dependency check

### DIFF
--- a/mainV2.py
+++ b/mainV2.py
@@ -22,6 +22,15 @@ import warnings
 from urllib3.exceptions import InsecureRequestWarning
 warnings.filterwarnings('ignore', category=InsecureRequestWarning)
 
+
+def get_whois_info(domain):
+    """Retrieve WHOIS information using whichever whois library is available."""
+    if hasattr(whois, "whois"):
+        return whois.whois(domain)
+    if hasattr(whois, "query"):
+        return whois.query(domain)
+    raise AttributeError("whois module has no whois or query function")
+
 class WebsiteVerificationTool:
     def __init__(self, root):
         self.root = root
@@ -1041,8 +1050,11 @@ class WebsiteVerificationTool:
             # 1. Registrar check using whois
             try:
                 print("Checking whois...")
-                w = whois.whois(domain)
-                result['registrar'] = str(w.registrar) if w.registrar else 'Unknown'
+                w = get_whois_info(domain)
+                registrar = getattr(w, 'registrar', None)
+                if isinstance(registrar, list):
+                    registrar = registrar[0]
+                result['registrar'] = str(registrar) if registrar else 'Unknown'
                 print(f"  Registrar: {result['registrar']}")
             except Exception as whois_error:
                 result['registrar'] = 'Whois lookup failed'
@@ -1339,14 +1351,16 @@ class WebsiteVerificationTool:
             
             # Check domain age (simplified)
             try:
-                w = whois.whois(domain)
-                if w.creation_date:
-                    creation_date = w.creation_date[0] if isinstance(w.creation_date, list) else w.creation_date
+                w = get_whois_info(domain)
+                creation_date = getattr(w, 'creation_date', None)
+                if isinstance(creation_date, list):
+                    creation_date = creation_date[0]
+                if creation_date:
                     age_days = (datetime.now() - creation_date).days
                     checks['domain_age_days'] = age_days
                     if age_days < 30:
                         checks['new_domain_warning'] = "Domain is less than 30 days old"
-            except:
+            except Exception:
                 pass
             
             # Check for HTTPS redirect
@@ -1853,10 +1867,13 @@ Additional Checks: {scan[12]}
 def install_requirements():
     """Install required packages"""
     required_packages = ['requests', 'python-whois']
-    
+
     for package in required_packages:
         try:
-            __import__(package.replace('-', '_'))
+            if package == 'python-whois':
+                __import__('whois')
+            else:
+                __import__(package.replace('-', '_'))
         except ImportError:
             print(f"Installing {package}...")
             subprocess.check_call([sys.executable, "-m", "pip", "install", package])

--- a/mainV3.py
+++ b/mainV3.py
@@ -28,6 +28,15 @@ import dns.exception  # NEW: For DNS exceptions
 from urllib3.exceptions import InsecureRequestWarning
 warnings.filterwarnings('ignore', category=InsecureRequestWarning)
 
+
+def get_whois_info(domain):
+    """Retrieve WHOIS information using whichever whois library is available."""
+    if hasattr(whois, "whois"):
+        return whois.whois(domain)
+    if hasattr(whois, "query"):
+        return whois.query(domain)
+    raise AttributeError("whois module has no whois or query function")
+
 class WebsiteVerificationTool:
     def __init__(self, root):
         self.root = root
@@ -1486,8 +1495,11 @@ class WebsiteVerificationTool:
             # 1. Registrar check using whois
             try:
                 print("Checking whois...")
-                w = whois.whois(domain)
-                result['registrar'] = str(w.registrar) if w.registrar else 'Unknown'
+                w = get_whois_info(domain)
+                registrar = getattr(w, 'registrar', None)
+                if isinstance(registrar, list):
+                    registrar = registrar[0]
+                result['registrar'] = str(registrar) if registrar else 'Unknown'
                 print(f"  Registrar: {result['registrar']}")
             except Exception as whois_error:
                 result['registrar'] = 'Whois lookup failed'
@@ -1794,14 +1806,16 @@ class WebsiteVerificationTool:
             
             # Check domain age (simplified)
             try:
-                w = whois.whois(domain)
-                if w.creation_date:
-                    creation_date = w.creation_date[0] if isinstance(w.creation_date, list) else w.creation_date
+                w = get_whois_info(domain)
+                creation_date = getattr(w, 'creation_date', None)
+                if isinstance(creation_date, list):
+                    creation_date = creation_date[0]
+                if creation_date:
                     age_days = (datetime.now() - creation_date).days
                     checks['domain_age_days'] = age_days
                     if age_days < 30:
                         checks['new_domain_warning'] = "Domain is less than 30 days old"
-            except:
+            except Exception:
                 pass
             
             # Check for HTTPS redirect
@@ -2628,11 +2642,13 @@ Additional Checks: {scan[15] if len(scan) > 15 else scan[12]}
 def install_requirements():
     """Install required packages"""
     required_packages = ['requests', 'python-whois', 'dnspython']  # Added dnspython for MX checks
-    
+
     for package in required_packages:
         try:
             if package == 'dnspython':
                 __import__('dns.resolver')  # Check for DNS library
+            elif package == 'python-whois':
+                __import__('whois')  # Module name differs from package
             else:
                 __import__(package.replace('-', '_'))
         except ImportError:


### PR DESCRIPTION
## Summary
- Add `get_whois_info` utility supporting both `whois.whois` and `whois.query` APIs.
- Update registrar and domain-age checks to use the new helper.
- Correct dependency installer to import `whois` module when verifying `python-whois`.

## Testing
- `python -m py_compile mainV1.py`
- `python -m py_compile mainV2.py`
- `python -m py_compile mainV3.py`


------
https://chatgpt.com/codex/tasks/task_e_689b467a25ac83279ae56c5e73e545f6