### PR TITLE
Use tree item IDs instead of ID column

### DIFF
--- a/mainV1.py
+++ b/mainV1.py
@@ -193,12 +193,11 @@ class WebsiteVerificationTool:
         list_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=(0, 10))
         
         # Treeview for websites with comprehensive columns
-        columns = ('ID', 'Name', 'URL', 'Last Checked', 'Status Code', 'SSL', 'Registrar', 'Changes', 'Risk Score', 'Issues')
+        columns = ('Name', 'URL', 'Last Checked', 'Status Code', 'SSL', 'Registrar', 'Changes', 'Risk Score', 'Issues')
         self.websites_tree = ttk.Treeview(list_frame, columns=columns, show='headings', selectmode='extended')
         
         # Configure column widths and headings
         column_configs = {
-            'ID': 40,
             'Name': 150,
             'URL': 250,
             'Last Checked': 120,
@@ -481,12 +480,14 @@ class WebsiteVerificationTool:
                 tag = 'low_risk'
             
             # Insert the row - this ensures exactly one row per website
-            self.websites_tree.insert('', tk.END, values=(
-                website_id, name, url, 
-                last_checked[:16] if last_checked else 'Never',
-                status_display, ssl_display, registrar_display,
-                changes_display, risk_display, issues_display
-            ), tags=(tag,))
+            self.websites_tree.insert(
+                '', tk.END, iid=str(website_id), text=str(website_id), values=(
+                    name, url,
+                    last_checked[:16] if last_checked else 'Never',
+                    status_display, ssl_display, registrar_display,
+                    changes_display, risk_display, issues_display
+                ), tags=(tag,)
+            )
         
         conn.close()
         
@@ -1224,7 +1225,8 @@ class WebsiteVerificationTool:
         def scan_thread():
             for item in selection:
                 values = self.websites_tree.item(item)['values']
-                website_id, url = values[0], values[2]
+                website_id = int(item)
+                url = values[1]
                 self.scan_website(website_id, url)
                 # Update UI after each scan
                 self.root.after(0, self.load_websites)
@@ -1247,7 +1249,7 @@ class WebsiteVerificationTool:
             cursor = conn.cursor()
             
             for item in selection:
-                website_id = self.websites_tree.item(item)['values'][0]
+                website_id = int(item)
                 cursor.execute("DELETE FROM scan_results WHERE website_id = ?", (website_id,))
                 cursor.execute("DELETE FROM websites WHERE id = ?", (website_id,))
             
@@ -1334,7 +1336,7 @@ class WebsiteVerificationTool:
         if not selection:
             return
         
-        website_id = self.websites_tree.item(selection[0])['values'][0]
+        website_id = int(selection[0])
         self.show_website_details_window(website_id)
     
     def show_website_details_window(self, website_id):

--- a/mainV2.py
+++ b/mainV2.py
@@ -232,12 +232,11 @@ class WebsiteVerificationTool:
         list_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=(0, 10))
         
         # Treeview for websites with comprehensive columns - UPDATED to include Domain Age
-        columns = ('ID', 'Name', 'URL', 'Last Checked', 'Status Code', 'SSL', 'Registrar', 'Domain Age', 'Changes', 'Risk Score', 'Issues')
+        columns = ('Name', 'URL', 'Last Checked', 'Status Code', 'SSL', 'Registrar', 'Domain Age', 'Changes', 'Risk Score', 'Issues')
         self.websites_tree = ttk.Treeview(list_frame, columns=columns, show='headings', selectmode='extended')
         
         # Configure column widths and headings - UPDATED to include Domain Age
         column_configs = {
-            'ID': 40,
             'Name': 150,
             'URL': 220,  # Slightly reduced to make room
             'Last Checked': 110,  # Slightly reduced
@@ -564,13 +563,15 @@ class WebsiteVerificationTool:
                 tag = 'low_risk'
             
             # Insert the row - UPDATED to include domain age
-            self.websites_tree.insert('', tk.END, values=(
-                website_id, name, url, 
-                last_checked[:16] if last_checked else 'Never',
-                status_display, ssl_display, registrar_display,
-                domain_age_display,  # NEW COLUMN DATA
-                changes_display, risk_display, issues_display
-            ), tags=(tag,))
+            self.websites_tree.insert(
+                '', tk.END, iid=str(website_id), text=str(website_id), values=(
+                    name, url,
+                    last_checked[:16] if last_checked else 'Never',
+                    status_display, ssl_display, registrar_display,
+                    domain_age_display,  # NEW COLUMN DATA
+                    changes_display, risk_display, issues_display
+                ), tags=(tag,)
+            )
         
         conn.close()
         
@@ -1447,7 +1448,8 @@ class WebsiteVerificationTool:
             total_selected = len(selection)
             for i, item in enumerate(selection, 1):
                 values = self.websites_tree.item(item)['values']
-                website_id, url = values[0], values[2]
+                website_id = int(item)
+                url = values[1]
                 print(f"\n--- Scanning {i}/{total_selected}: {url} ---")
                 self.scan_website_with_retries(website_id, url)  # Use retry method
                 # Update UI after each scan
@@ -1471,7 +1473,7 @@ class WebsiteVerificationTool:
             cursor = conn.cursor()
             
             for item in selection:
-                website_id = self.websites_tree.item(item)['values'][0]
+                website_id = int(item)
                 cursor.execute("DELETE FROM scan_results WHERE website_id = ?", (website_id,))
                 cursor.execute("DELETE FROM websites WHERE id = ?", (website_id,))
             
@@ -1558,7 +1560,7 @@ class WebsiteVerificationTool:
         if not selection:
             return
         
-        website_id = self.websites_tree.item(selection[0])['values'][0]
+        website_id = int(selection[0])
         self.show_website_details_window(website_id)
     
     def show_website_details_window(self, website_id):

--- a/mainV3.py
+++ b/mainV3.py
@@ -426,14 +426,13 @@ class WebsiteVerificationTool:
 
         # Treeview for websites with comprehensive columns - UPDATED to include MX Records and Comments
         columns = (
-            'ID', 'Name', 'URL', 'Last Checked', 'Status Code', 'SSL', 'Registrar',
+            'Name', 'URL', 'Last Checked', 'Status Code', 'SSL', 'Registrar',
             'Domain Age', 'MX Records', 'Changes', 'Risk Score', 'Issues', 'Comments'
         )
         self.websites_tree = ttk.Treeview(list_frame, columns=columns, show='headings', selectmode='extended')
 
         # Configure column widths and headings - UPDATED to include MX Records and Comments
         column_configs = {
-            'ID': 40,
             'Name': 140,  # Slightly reduced
             'URL': 200,   # Slightly reduced
             'Last Checked': 100,  # Slightly reduced
@@ -972,16 +971,17 @@ class WebsiteVerificationTool:
             
 
             # Insert the row - UPDATED to include MX records and button placeholder
-            item_id = self.websites_tree.insert('', tk.END, values=(
-
-                website_id, name, url,
-                last_checked[:16] if last_checked else 'Never',
-                status_display, ssl_display, registrar_display,
-                domain_age_display,  # Domain Age column
-                mx_display,  # NEW: MX Records column
-                changes_display, risk_display, issues_display,
-
-            ), tags=(tag,))
+            item_id = self.websites_tree.insert(
+                '', tk.END, iid=str(website_id), text=str(website_id), values=(
+                    name, url,
+                    last_checked[:16] if last_checked else 'Never',
+                    status_display, ssl_display, registrar_display,
+                    domain_age_display,  # Domain Age column
+                    mx_display,  # NEW: MX Records column
+                    changes_display, risk_display, issues_display,
+                    ''
+                ), tags=(tag,)
+            )
 
             # Overlay a button for comments on this row
             btn = ttk.Button(
@@ -2085,7 +2085,8 @@ class WebsiteVerificationTool:
             futures = []
             for item in selection:
                 values = self.websites_tree.item(item)['values']
-                website_id, url = values[0], values[2]
+                website_id = int(item)
+                url = values[1]
                 futures.append(executor.submit(self.scan_website_with_retries, website_id, url))
 
             completed = 0
@@ -2122,7 +2123,7 @@ class WebsiteVerificationTool:
             cursor = conn.cursor()
             
             for item in selection:
-                website_id = self.websites_tree.item(item)['values'][0]
+                website_id = int(item)
                 cursor.execute("DELETE FROM scan_results WHERE website_id = ?", (website_id,))
                 cursor.execute("DELETE FROM websites WHERE id = ?", (website_id,))
             
@@ -2140,7 +2141,7 @@ class WebsiteVerificationTool:
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         for item in selection:
-            website_id = self.websites_tree.item(item)['values'][0]
+            website_id = int(item)
             cursor.execute("UPDATE websites SET manual_status = ? WHERE id = ?", (status, website_id))
         conn.commit()
         conn.close()
@@ -2241,7 +2242,7 @@ class WebsiteVerificationTool:
         if not selection:
             return
         
-        website_id = self.websites_tree.item(selection[0])['values'][0]
+        website_id = int(selection[0])
         self.show_website_details_window(website_id)
     
     def show_website_details_window(self, website_id):


### PR DESCRIPTION
## Summary
- Remove the ID column from website tables and column configs
- Store row IDs in the Treeview item `iid` and update selection handlers to read IDs from the item

## Testing
- `python -m py_compile mainV1.py mainV2.py mainV3.py`


------
https://chatgpt.com/codex/tasks/task_e_689b7d9b31208327a0c4ec801ffd4e02