### PR TITLE
Use deep red style for high-risk website rows

### DIFF
--- a/mainV1.py
+++ b/mainV1.py
@@ -492,7 +492,8 @@ class WebsiteVerificationTool:
         conn.close()
         
         # Configure tags for color coding
-        self.websites_tree.tag_configure('high_risk', background='#ffebee')  # Light red
+        # Use deep red with white text for high-risk entries
+        self.websites_tree.tag_configure('high_risk', background='#b71c1c', foreground='white')
         self.websites_tree.tag_configure('medium_risk', background='#fff3e0')  # Light orange
         self.websites_tree.tag_configure('low_risk', background='#e8f5e8')  # Light green
         self.websites_tree.tag_configure('not_scanned', background='#f5f5f5')  # Light gray

--- a/mainV2.py
+++ b/mainV2.py
@@ -576,7 +576,8 @@ class WebsiteVerificationTool:
         conn.close()
         
         # Configure tags for color coding (enhanced with new domain tag)
-        self.websites_tree.tag_configure('high_risk', background='#ffebee')  # Light red
+        # Use deep red with white text for high-risk entries
+        self.websites_tree.tag_configure('high_risk', background='#b71c1c', foreground='white')
         self.websites_tree.tag_configure('medium_risk', background='#fff3e0')  # Light orange
         self.websites_tree.tag_configure('low_risk', background='#e8f5e8')  # Light green
         self.websites_tree.tag_configure('not_scanned', background='#f5f5f5')  # Light gray

--- a/mainV3.py
+++ b/mainV3.py
@@ -991,7 +991,8 @@ class WebsiteVerificationTool:
         # Configure tags for color coding (enhanced with MX warning tag and manual status)
         self.websites_tree.tag_configure('safe_manual', background='#bbdefb')
         self.websites_tree.tag_configure('high_risk_manual', background='#b71c1c', foreground='white')
-        self.websites_tree.tag_configure('high_risk', background='#ffebee')  # Light red
+        # Use deep red with white text for high-risk entries
+        self.websites_tree.tag_configure('high_risk', background='#b71c1c', foreground='white')
         self.websites_tree.tag_configure('medium_risk', background='#fff3e0')  # Light orange
         self.websites_tree.tag_configure('low_risk', background='#e8f5e8')  # Light green
 


### PR DESCRIPTION
## Summary
- Align automatic and manual high-risk indicators with a deep red (#b71c1c) background and white text for improved readability across dashboard versions

## Testing
- `python -m py_compile mainV1.py mainV2.py mainV3.py`


------
https://chatgpt.com/codex/tasks/task_e_689b81c353088327b7756ceb877df8cc