### PR TITLE
Handle RDAP lookup failures in risk scoring

### DIFF
--- a/mainV3.py
+++ b/mainV3.py
@@ -1926,7 +1926,7 @@ class WebsiteVerificationTool:
             score += 20
         
         # Registrar issues
-        if scan_result['registrar'] in ['Unknown', 'Whois lookup failed']:
+        if scan_result['registrar'] in ['Unknown', 'Whois lookup failed', 'RDAP lookup failed']:
             score += 15
         
         # NEW: MX record issues

--- a/tests/test_calculate_risk_score.py
+++ b/tests/test_calculate_risk_score.py
@@ -1,0 +1,35 @@
+import types
+import sys
+
+
+def test_rdap_lookup_failed_increases_risk_score(monkeypatch):
+    """Ensure RDAP lookup failures affect the risk score."""
+    # Provide minimal stubs for external dependencies required by mainV3
+    sys.modules['requests'] = types.ModuleType("requests")
+
+    dns_module = types.ModuleType("dns")
+    dns_resolver = types.ModuleType("dns.resolver")
+    dns_exception = types.ModuleType("dns.exception")
+    dns_exception.DNSException = Exception
+    dns_module.resolver = dns_resolver
+    dns_module.exception = dns_exception
+    sys.modules['dns'] = dns_module
+    sys.modules['dns.resolver'] = dns_resolver
+    sys.modules['dns.exception'] = dns_exception
+
+    urllib3_module = types.ModuleType("urllib3")
+    urllib3_exceptions = types.ModuleType("urllib3.exceptions")
+    urllib3_exceptions.InsecureRequestWarning = type("InsecureRequestWarning", (Warning,), {})
+    urllib3_module.exceptions = urllib3_exceptions
+    sys.modules['urllib3'] = urllib3_module
+    sys.modules['urllib3.exceptions'] = urllib3_exceptions
+
+    from mainV3 import WebsiteVerificationTool
+
+    tool = WebsiteVerificationTool.__new__(WebsiteVerificationTool)
+    scan_result = {
+        'ssl_valid': True,
+        'status_code': 200,
+        'registrar': 'RDAP lookup failed'
+    }
+    assert tool.calculate_risk_score(scan_result) == 15


### PR DESCRIPTION
## Summary
- Treat registrar field value "RDAP lookup failed" as a risk-increasing issue
- Add regression test to ensure RDAP lookup failures raise risk score

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ca1d4c5fc8327852e79feeae839b6