### PR TITLE
Handle RDAP creation events

### DIFF
--- a/mainV3.py
+++ b/mainV3.py
@@ -1910,7 +1910,9 @@ class WebsiteVerificationTool:
                 creation_date = None
                 if rdap:
                     for event in rdap.get('events', []):
-                        if event.get('eventAction') == 'registration':
+                        # RDAP may report the domain's start date as either
+                        # "registration" or "creation" depending on the registry
+                        if event.get('eventAction') in ("registration", "creation"):
                             date_str = event.get('eventDate')
                             if date_str:
                                 creation_date = datetime.fromisoformat(

--- a/tests/test_domain_age_creation.py
+++ b/tests/test_domain_age_creation.py
@@ -1,0 +1,43 @@
+import types
+import sys
+from datetime import datetime, timezone
+
+
+def test_domain_age_uses_creation_event(monkeypatch):
+    """Domain age should be calculated when RDAP uses the 'creation' event."""
+    # Provide minimal stubs for external dependencies required by mainV3
+    sys.modules['requests'] = types.ModuleType("requests")
+
+    dns_module = types.ModuleType("dns")
+    dns_resolver = types.ModuleType("dns.resolver")
+    dns_exception = types.ModuleType("dns.exception")
+    dns_exception.DNSException = Exception
+    dns_module.resolver = dns_resolver
+    dns_module.exception = dns_exception
+    sys.modules['dns'] = dns_module
+    sys.modules['dns.resolver'] = dns_resolver
+    sys.modules['dns.exception'] = dns_exception
+
+    urllib3_module = types.ModuleType("urllib3")
+    urllib3_exceptions = types.ModuleType("urllib3.exceptions")
+    urllib3_exceptions.InsecureRequestWarning = type("InsecureRequestWarning", (Warning,), {})
+    urllib3_module.exceptions = urllib3_exceptions
+    sys.modules['urllib3'] = urllib3_module
+    sys.modules['urllib3.exceptions'] = urllib3_exceptions
+
+    from mainV3 import WebsiteVerificationTool
+
+    tool = WebsiteVerificationTool.__new__(WebsiteVerificationTool)
+
+    rdap = {
+        'events': [
+            {
+                'eventAction': 'creation',
+                'eventDate': '2000-01-01T00:00:00Z'
+            }
+        ]
+    }
+
+    checks = tool.additional_security_checks('https://example.com', 'example.com', rdap)
+    expected_age = (datetime.now(timezone.utc) - datetime(2000, 1, 1, tzinfo=timezone.utc)).days
+    assert checks['domain_age_days'] == expected_age


### PR DESCRIPTION
## Summary
- interpret both `registration` and `creation` events when determining domain age
- add regression test ensuring `creation` event still yields domain age

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cad5d07708327add19d86855e394d