### PR TITLE
Add theme manager hooks and theme selection

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,11 +1,23 @@
+import argparse
 import tkinter as tk
 from ui import WebsiteVerificationTool
+from ui.theme import _HAS_TTKB
 
 def main():
+    parser = argparse.ArgumentParser(description="Website Verification")
+    if _HAS_TTKB:
+        parser.add_argument(
+            "--theme",
+            default="litera",
+            help="ttkbootstrap theme to use",
+        )
+    args = parser.parse_args()
+
     root = tk.Tk()
     root.title("Website Verification")
-    app = WebsiteVerificationTool(root, db_path="website_verification.db")
-    app.load_websites()           # populate initial table
+    theme = getattr(args, "theme", None)
+    app = WebsiteVerificationTool(root, db_path="website_verification.db", theme=theme)
+    app.load_websites()  # populate initial table
     root.mainloop()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Apply theme manager to root window and website tree
- Add optional theme selection combobox and CLI `--theme` argument

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d08fb475083278a27b45fd9d385a5